### PR TITLE
Various bug fixes on repo cloning.

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -57,9 +57,9 @@ pub fn sparse_checkout(
         local_dir: tempfile::tempdir()?,
     });
 
-    println!("Cloning {}:{}", dir.remote_url.url, dir.remote_url.branch);
-    exec_git(&dir, &["init"])?;
-    exec_git(&dir, &["config", "core.sparsecheckout", "true"])?;
+    println!("Cloning {}:{} into {}", dir.remote_url.url, dir.remote_url.branch, dir.path()?);
+    exec_git(&dir, &["clone", "--filter=tree:0", "--no-checkout", &dir.remote_url.url, "."])?;
+    exec_git(&dir, &["sparse-checkout", "init", "--cone"])?;
 
     let mut checkout_args = Vec::from(["sparse-checkout", "set"]);
     for path in &dir.target_files {
@@ -67,8 +67,7 @@ pub fn sparse_checkout(
     }
 
     exec_git(&dir, &checkout_args)?;
-    exec_git(&dir, &["remote", "add", "origin", &dir.remote_url.url],)?;
-    exec_git(&dir, &["pull", "origin", &dir.remote_url.branch])?;
+    exec_git(&dir, &["checkout"])?;
 
     return Ok(dir);
 }

--- a/src/git_url_parser.rs
+++ b/src/git_url_parser.rs
@@ -18,7 +18,7 @@ pub fn parse_url(url: &str) -> Result<GitUrl, GitDownError> {
 }
 
 pub fn is_shortcut_url(url: &str) -> bool {
-    let regex = Regex::new(r"^\w+:.*$").unwrap();
+    let regex = Regex::new(r"^\w+:\w+*$").unwrap();
 
     regex.is_match(url)
 }
@@ -79,7 +79,7 @@ fn read_url_part(captures: &Captures, name: &str) -> Result<String, GitDownError
 }
 
 fn parse_http_url(url: &str) -> Result<GitUrl, GitDownError> {
-    let regex = Regex::new(r"^.*/(?P<url>(?P<name>[^.:/]+)(\.git))?/?:(?P<branch>[^.]+)$").unwrap();
+    let regex = Regex::new(r"^(?P<url>.*/(?P<name>[^.:/]+)(\.git)?)/?:(?P<branch>[^.]+)$").unwrap();
     let captures = match regex.captures(url) {
         Some(value) => value,
         None => {


### PR DESCRIPTION
Fixes:
- App was still cloning entire repo on git-pull (resolved this by combining sparse-checkout with a partial clone - see [this article](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/) for more details)

  ```sh
  # This was making a 1GB+ download initially, it's now reduced to ~ 40MB.
  git down git@github.com:ryanoasis/nerd-fonts:master patched-fonts/CascadiaCode  
  ```
- Handling of non-shortcut url (was throwing error 'invalid url')