### PR TITLE
fix: Check for supported shortcut codes only for now

### DIFF
--- a/src/git_url_parser.rs
+++ b/src/git_url_parser.rs
@@ -18,7 +18,8 @@ pub fn parse_url(url: &str) -> Result<GitUrl, GitDownError> {
 }
 
 pub fn is_shortcut_url(url: &str) -> bool {
-    let regex = Regex::new(r"^\w+:\w+*$").unwrap();
+    // FIXME: Do not rely on hardcoded forms of the shortcuts. 
+    let regex = Regex::new(r"^(bb|gh|gl|sf):.*$").unwrap();
 
     regex.is_match(url)
 }


### PR DESCRIPTION
Currently hard-coded the supported shortcuts in the Regex.
Handling a small regression from #2 